### PR TITLE
Add deprecation notice

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 Pylint Strict Informational
 ===========================
 
+   As of pylint 2.9.0, the `fail-on=I configuration option <https://pylint.pycqa.org/en/latest/user_guide/configuration/all-options.html#fail-on>`_
+   can be used instead of this plugin. Therefore, this plugin is deprecated.
+
 Pylint plugin to make it fail when an informational message (the "I" category) is found.
 
 Pylint >= 2.4.0 is required (in order for ``pylint.constants`` module to exist).


### PR DESCRIPTION
With pylint >= 2.9.0, `fail-on=I` can be used instead of this plugin.